### PR TITLE
fix: fixed spritesheet loadsprites method bug

### DIFF
--- a/ig/sprite/SpriteSheet.java
+++ b/ig/sprite/SpriteSheet.java
@@ -314,8 +314,8 @@ public class SpriteSheet extends Sprite {
             for(int j = 0; j < columns; j++) {
                 sprites[i][j] = new Sprite (
                     getImage().getSubimage (
-                        spriteWidth * i + gap * i,
-                        spriteHeight * j + gap * j,
+                        spriteWidth * j + gap * j,
+                        spriteHeight * i + gap * i,
                         spriteWidth,
                         spriteHeight
                     )


### PR DESCRIPTION
Fixed the bug of the method `loadSprites()` from the class `SpriteSheet` which was being caused by a tentative to use the method `java.awt.image.BufferedImage.getSubImage(int x, int y, int w, int h)` passing coordinate arguments which were outside of the `BufferedImage` to be cropped.

closes #21 