### PR TITLE
fix: updatecurrentframe method

### DIFF
--- a/ig/object/Tile.java
+++ b/ig/object/Tile.java
@@ -239,7 +239,7 @@ public abstract class Tile {
 
 
     private void updateCurrentFrame() {
-        this.currentFrame = spriteSheet.getSprites()[frameX][frameY];
+        this.currentFrame = spriteSheet.getSprites()[frameY][frameX];
     }
 
     public Sprite getCurrentFrame() {


### PR DESCRIPTION
Made the `updateCurrentFrame()` method from the `Tile` class update correctly the current frame of the tile, making it access the right sprite from its sheet.

closes #25 